### PR TITLE
Adding pace mode (unit) switch dialog on pace view long press.

### DIFF
--- a/app/src/main/java/com/marcospoerl/simplypace/adapter/TermAdapter.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/adapter/TermAdapter.java
@@ -18,7 +18,13 @@ public class TermAdapter extends DragItemAdapter<Term, TermAdapter.ViewHolder> {
         void onItemClicked(HolderView holderView);
     }
 
+    public interface OnItemLongClickedListener {
+        void onItemLongClicked(HolderView holderView);
+    }
+
     private OnItemClickedListener onItemClickedListener;
+    private OnItemLongClickedListener onItemLongClickedListener;
+
 
     public TermAdapter() {
         setItemList(new LinkedList<Term>());
@@ -27,6 +33,10 @@ public class TermAdapter extends DragItemAdapter<Term, TermAdapter.ViewHolder> {
 
     public void setOnItemClickedListener(OnItemClickedListener onItemClickedListener) {
         this.onItemClickedListener = onItemClickedListener;
+    }
+
+    public void setOnItemLongClickedListener(OnItemLongClickedListener onItemLongClickedListener) {
+        this.onItemLongClickedListener = onItemLongClickedListener;
     }
 
     public void add(Term term, int location) {
@@ -81,6 +91,14 @@ public class TermAdapter extends DragItemAdapter<Term, TermAdapter.ViewHolder> {
             if (onItemClickedListener != null && view instanceof HolderView) {
                 onItemClickedListener.onItemClicked((HolderView) view);
             }
+        }
+
+        @Override
+        public boolean onItemLongClicked(View view) {
+            if (onItemLongClickedListener != null && view instanceof HolderView) {
+                onItemLongClickedListener.onItemLongClicked((HolderView) view);
+            }
+            return true;
         }
     }
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/model/DistanceTerm.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/model/DistanceTerm.java
@@ -53,4 +53,9 @@ public class DistanceTerm implements Term {
     public int hashCode() {
         return Objects.hashCode(this.distanceInMeter);
     }
+
+    @Override
+    public String asText() {
+        return String.format("%.3f km", getDistanceInKilometer().doubleValue());
+    }
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/model/PaceMode.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/model/PaceMode.java
@@ -1,0 +1,5 @@
+package com.marcospoerl.simplypace.model;
+
+public enum PaceMode {
+    KMH, MIN, MIN100
+}

--- a/app/src/main/java/com/marcospoerl/simplypace/model/PaceTerm.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/model/PaceTerm.java
@@ -3,10 +3,35 @@ package com.marcospoerl.simplypace.model;
 import com.google.common.base.Objects;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.concurrent.TimeUnit;
+
 
 public class PaceTerm implements Term {
 
     private BigDecimal secondsPerKilometer = BigDecimal.ZERO;
+    private PaceMode paceMode;
+
+    public void setPaceMode(PaceMode paceMode) {
+        this.paceMode = paceMode;
+    }
+
+    public void setPace(BigDecimal pace){
+            if (pace.compareTo(BigDecimal.ZERO) == 0) {
+                this.secondsPerKilometer = BigDecimal.ZERO;
+            } else {
+                switch (paceMode) {
+                    case MIN:
+                        this.secondsPerKilometer = pace;
+                        break;
+                    case KMH:
+                        this.secondsPerKilometer = SECONDS_PER_HOUR.divide(pace, MathContext.DECIMAL128);
+                        break;
+                    case MIN100:
+                        this.secondsPerKilometer = pace.multiply(TEN);
+                }
+            }
+    }
 
     public void setSecondsPerKilometer(BigDecimal secondsPerKilometer) {
         this.secondsPerKilometer = secondsPerKilometer;
@@ -14,6 +39,17 @@ public class PaceTerm implements Term {
 
     public BigDecimal getSecondsPerKilometer() {
         return secondsPerKilometer;
+    }
+
+    private BigDecimal getKilometersPerHour() {
+        if (secondsPerKilometer.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return SECONDS_PER_HOUR.divide(secondsPerKilometer, MathContext.DECIMAL128);
+    }
+
+    private BigDecimal getSecondsPerHundredMeter(){
+        return secondsPerKilometer.divide(TEN, MathContext.DECIMAL128);
     }
 
     @Override
@@ -43,5 +79,23 @@ public class PaceTerm implements Term {
     @Override
     public int hashCode() {
         return Objects.hashCode(this.secondsPerKilometer);
+    }
+
+    public String asText() {
+        switch (paceMode) {
+            case MIN:
+                Long secondsPerKilometerL = secondsPerKilometer.longValue();
+                return String.format("%d:%02d min/km",
+                        TimeUnit.SECONDS.toMinutes(secondsPerKilometerL),
+                        TimeUnit.SECONDS.toSeconds(secondsPerKilometerL) - TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(secondsPerKilometerL)));
+            case KMH:
+                return String.format("%,.2f km/h", getKilometersPerHour());
+            case MIN100:
+                Long secondsPerHundretMeter = getSecondsPerHundredMeter().longValue();
+                return String.format("%d:%02d min/100m",
+                        TimeUnit.SECONDS.toMinutes(secondsPerHundretMeter),
+                        TimeUnit.SECONDS.toSeconds(secondsPerHundretMeter) - TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(secondsPerHundretMeter)));
+        }
+        return null;
     }
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/model/Term.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/model/Term.java
@@ -8,8 +8,10 @@ public interface Term {
     int TYPE_TIME = 1;
     int TYPE_PACE = 2;
 
+    BigDecimal TEN = new BigDecimal(10);
     BigDecimal ONE_THOUSAND = new BigDecimal(1000);
+    BigDecimal SECONDS_PER_HOUR = new BigDecimal(3600);
 
     int getType();
-
+    String asText();
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/model/TimeTerm.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/model/TimeTerm.java
@@ -3,6 +3,7 @@ package com.marcospoerl.simplypace.model;
 import com.google.common.base.Objects;
 
 import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
 
 public class TimeTerm implements Term {
 
@@ -43,5 +44,14 @@ public class TimeTerm implements Term {
     @Override
     public int hashCode() {
         return Objects.hashCode(this.timeInSeconds);
+    }
+
+    @Override
+    public String asText() {
+        final long seconds = getTimeInSeconds().longValue();
+        return String.format("%02dh:%02dm:%02ds",
+                TimeUnit.SECONDS.toHours(seconds),
+                TimeUnit.SECONDS.toMinutes(seconds) - TimeUnit.HOURS.toMinutes(TimeUnit.SECONDS.toHours(seconds)),
+                TimeUnit.SECONDS.toSeconds(seconds) - TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(seconds)));
     }
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/views/DistanceView.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/views/DistanceView.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.util.AttributeSet;
 
 import com.marcospoerl.simplypace.R;
-import com.marcospoerl.simplypace.model.DistanceTerm;
 
 public class DistanceView extends HolderView {
 
@@ -33,13 +32,5 @@ public class DistanceView extends HolderView {
                 this.captionTextView.setText(R.string.distance_caption_2);
                 break;
         }
-    }
-
-    @Override
-    protected void bind() {
-        final DistanceTerm distanceTerm = (DistanceTerm) this.term;
-        final double km = distanceTerm.getDistanceInKilometer().doubleValue();
-        final String text = String.format("%.3f km", km);
-        this.valueTextView.setText(text);
     }
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/views/HolderView.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/views/HolderView.java
@@ -55,5 +55,7 @@ public abstract class HolderView extends CardView {
         return term;
     }
 
-    protected abstract void bind();
+    protected void bind() {
+        this.valueTextView.setText(term.asText());
+    }
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/views/PaceView.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/views/PaceView.java
@@ -4,9 +4,6 @@ import android.content.Context;
 import android.util.AttributeSet;
 
 import com.marcospoerl.simplypace.R;
-import com.marcospoerl.simplypace.model.PaceTerm;
-
-import java.util.concurrent.TimeUnit;
 
 public class PaceView extends HolderView {
 
@@ -35,15 +32,5 @@ public class PaceView extends HolderView {
                 this.captionTextView.setText(R.string.pace_caption_2);
                 break;
         }
-    }
-
-    @Override
-    protected void bind() {
-        final PaceTerm paceTerm = (PaceTerm) this.term;
-        final long seconds = paceTerm.getSecondsPerKilometer().longValue();
-        final String text = String.format("%d:%02d min/km",
-                TimeUnit.SECONDS.toMinutes(seconds),
-                TimeUnit.SECONDS.toSeconds(seconds) - TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(seconds)));
-        this.valueTextView.setText(text);
     }
 }

--- a/app/src/main/java/com/marcospoerl/simplypace/views/TimeView.java
+++ b/app/src/main/java/com/marcospoerl/simplypace/views/TimeView.java
@@ -4,9 +4,6 @@ import android.content.Context;
 import android.util.AttributeSet;
 
 import com.marcospoerl.simplypace.R;
-import com.marcospoerl.simplypace.model.TimeTerm;
-
-import java.util.concurrent.TimeUnit;
 
 public class TimeView extends HolderView {
 
@@ -35,16 +32,5 @@ public class TimeView extends HolderView {
                 this.captionTextView.setText(R.string.time_caption_2);
                 break;
         }
-    }
-
-    @Override
-    protected void bind() {
-        final TimeTerm timeTerm = (TimeTerm) this.term;
-        final long seconds = timeTerm.getTimeInSeconds().longValue();
-        final String text = String.format("%02dh:%02dm:%02ds",
-                TimeUnit.SECONDS.toHours(seconds),
-                TimeUnit.SECONDS.toMinutes(seconds) - TimeUnit.HOURS.toMinutes(TimeUnit.SECONDS.toHours(seconds)),
-                TimeUnit.SECONDS.toSeconds(seconds) - TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(seconds)));
-        this.valueTextView.setText(text);
     }
 }

--- a/app/src/main/res/values-de/pace_modes.xml
+++ b/app/src/main/res/values-de/pace_modes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="pace_modes_array">
+        <item>Running pace (min/km)</item>
+        <item>Fahrgeschwindigkeit (km/h)</item>
+        <item>Schwimm splits (min/100m)</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -15,4 +15,5 @@
     <string name="time_caption_1">&#8230; mit dieser Zeit &#8230;</string>
     <string name="time_caption_2">&#8230; ergibt diese Zeit</string>
     <string name="title_distance_dialog">Strecke</string>
+    <string name="title_pace_mode_dialog">Pace Modus</string>
 </resources>

--- a/app/src/main/res/values/pace_modes.xml
+++ b/app/src/main/res/values/pace_modes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="pace_modes_array">
+        <item>Running pace (min/km)</item>
+        <item>Riding speed (km/h)</item>
+        <item>Swim splits (min/100m)</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="time_caption_2">&#8230; results in this time</string>
     <string name="pace_caption_2">&#8230; results in this pace</string>
     <string name="title_distance_dialog">Distance</string>
+    <string name="title_pace_mode_dialog">Pace mode</string>
 </resources>


### PR DESCRIPTION
This is aimed at making simply pace more usable for other sports than running. In cycling we use km/h as a measure for pace and in swimming we use 100m splits. A long press on the pace view opens a dialog to choose between the three pace modes.

The current pace mode is kept in the PaceTerm and persisted as shared preference. The  picker is implemented along the lines of the current implementation. The text generation for the views has been slightly refactored and is done inside the respective Term implementation which allows to reflect the pace mode. It also makes the binding of the view more generic such that it could be moved to the HolderView.